### PR TITLE
"Inverse selection" and "Uncheck all" for app selection activity

### DIFF
--- a/res/menu/apps_menu.xml
+++ b/res/menu/apps_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:id="@+id/inverse_apps" android:title="@string/inverse" android:showAsAction="ifRoom"></item>
+    <item android:id="@+id/uncheck_all_apps" android:title="@string/uncheck_all" android:showAsAction="ifRoom"></item>
+    
+
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="app_name">Screen Notifications</string>
     <string name="description">Screen Notifications will turn your screen on when you get a 
         notification from the selected apps. The screen will not turn on if your device is in your pocket.</string>
+    <string name="inverse">Inverse</string>
+    <string name="uncheck_all">Uncheck all</string>
 </resources>

--- a/src/com/lukekorth/screennotifications/AppsActivity.java
+++ b/src/com/lukekorth/screennotifications/AppsActivity.java
@@ -1,17 +1,21 @@
 package com.lukekorth.screennotifications;
 
+import java.util.Collections;
+import java.util.List;
+
 import android.app.ProgressDialog;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceScreen;
-
-import java.util.Collections;
-import java.util.List;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 
 public class AppsActivity extends PreferenceActivity {
 
@@ -22,9 +26,50 @@ public class AppsActivity extends PreferenceActivity {
         AppLoader task = new AppLoader();
         task.execute();
     }
+    
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+    	MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.apps_menu, menu);
+
+        return true;
+    }
+    
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+    	int itemId = item.getItemId();
+    	boolean check;
+
+    	switch (itemId) {
+
+	    	case R.id.uncheck_all_apps: case R.id.inverse_apps:
+	    		PreferenceScreen ps = this.getPreferenceScreen();
+	    		PreferenceCategory pc = (PreferenceCategory) ps.getPreference(0);
+
+	    		for (int i = 0; i < pc.getPreferenceCount(); i++) {
+	    			Preference preference = pc.getPreference(i);
+
+	    			if (preference instanceof CheckBoxPreference) {
+	    				CheckBoxPreference checkboxPreference = (CheckBoxPreference) preference;
+
+	    				// should've used something like strategy pattern here
+	    				if (itemId == R.id.uncheck_all_apps) {
+	    					check = false;
+	    				} else {
+	    					check = !checkboxPreference.isChecked();
+	    				}
+
+	    				checkboxPreference.setChecked(check);
+	    			}
+	    		}
+
+	    		return true;
+    	}
+
+		return false;
+    }
 
     private class AppLoader extends AsyncTask<Void, Void, Void>{
-
         ProgressDialog loadingDialog;
         PreferenceScreen root;
 


### PR DESCRIPTION
Hello,

i've added these two options to improve the usability.

For example: I'd like to enable screen notifications for all apps. Would've been a PITA w/o the "Inverse selection" option.

Jan Bollacke
