### PR TITLE
Use accelerometer and other fixes

### DIFF
--- a/ScreenNotifications/build.gradle
+++ b/ScreenNotifications/build.gradle
@@ -1,4 +1,6 @@
+import groovy.swing.SwingBuilder
 apply plugin: 'com.android.application'
+
 
 android {
     compileSdkVersion 23
@@ -7,24 +9,31 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 18
-        versionName "0.12.0"
+        versionCode 19
+        versionName "0.13.0"
     }
 
-//    signingConfigs {
-//        release {
-//            storeFile file(System.properties['KEYSTORE_PATH'])
-//            storePassword "PLACEHOLDER"
-//            keyAlias System.properties['KEYSTORE_EMAIL']
-//            keyPassword "PLACEHOLDER"
-//        }
-//    }
+    signingConfigs {
+        release {
+            try {
+                storeFile file(System.properties['KEYSTORE_PATH'])
+                storePassword "PLACEHOLDER"
+                keyAlias System.properties['KEYSTORE_EMAIL']
+                keyPassword "PLACEHOLDER"
+            }
+            catch (ex) {
+                println "You should define KEYSTORE_PATH and KEYSTORE_EMAIL in a gradle.properties file."
+                //throw new InvalidUserDataException("You should define KEYSTORE_PATH and KEYSTORE_EMAIL in a gradle.properties file.")
+            }
 
-//    buildTypes {
-//        release {
-//            signingConfig signingConfigs.release
-//        }
-//    }
+        }
+    }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
 
     lintOptions {
         abortOnError false
@@ -37,22 +46,42 @@ dependencies {
     compile 'fr.nicolaspomepuy:discreetapprate:2.0.3@aar'
 }
 
-// borrowed from https://www.timroes.de/2014/01/19/using-password-prompts-with-gradle-build-files/
-// and https://www.timroes.de/2013/09/22/handling-signing-configs-with-gradle/
-//gradle.taskGraph.whenReady { taskGraph ->
-    // Only execute when we are trying to assemble a release build
-//    if(taskGraph.hasTask(':ScreenNotifications:assembleRelease') || taskGraph.hasTask(':ScreenNotifications:installRelease')) {
-//        def password = System.console().readPassword("\nPlease enter key passphrase: ")
-//
-//        if(password.size() <= 0) {
-//            throw new InvalidUserDataException("You must enter a password to proceed.")
-//        }
-//
-//        // Must create String because System.readPassword() returns char[]
-//        // (and assigning that below fails silently)
-//        password = new String(password)
-//
-//        android.signingConfigs.release.storePassword = password
-//        android.signingConfigs.release.keyPassword = password
-//    }
-//}
+// see Tim Roes https://www.timroes.de/2014/01/19/using-password-prompts-with-gradle-build-files/
+gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.hasTask(':ScreenNotifications:assembleRelease')) {
+        if(android.signingConfigs.release.storePassword.size() <= 0) {
+            def pass = ''
+            if (System.console() == null) {
+                new SwingBuilder().edt {
+                    dialog(modal: true, // Otherwise the build will continue running before you closed the dialog
+                            title: 'Enter password', // Dialog title
+                            alwaysOnTop: true, // pretty much what the name says
+                            resizable: false, // Don't allow the user to resize the dialog
+                            locationRelativeTo: null, // Place dialog in center of the screen
+                            pack: true, // We need to pack the dialog (so it will take the size of it's children)
+                            show: true // Let's show it
+                    ) {
+                        vbox { // Put everything below each other
+                            label(text: "Please enter key passphrase:")
+                            input = passwordField()
+                            button(defaultButton: true, text: 'OK', actionPerformed: {
+                                pass = input.password; // Set pass variable to value of input field
+                                dispose(); // Close dialog
+                            })
+                        } // vbox end
+                    } // dialog end
+                } // edt end
+            } else {
+                pass = System.console().readPassword("\nPlease enter key passphrase: ")
+            }
+
+            if (pass.size() <= 0) {
+                throw new InvalidUserDataException("You must enter a password to proceed.")
+            }
+
+            pass = new String(pass)
+            android.signingConfigs.release.storePassword = pass
+            android.signingConfigs.release.keyPassword = pass
+        }
+    }
+}

--- a/ScreenNotifications/build.gradle
+++ b/ScreenNotifications/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 16
@@ -11,20 +11,20 @@ android {
         versionName "0.12.0"
     }
 
-    signingConfigs {
-        release {
-            storeFile file(System.properties['KEYSTORE_PATH'])
-            storePassword "PLACEHOLDER"
-            keyAlias System.properties['KEYSTORE_EMAIL']
-            keyPassword "PLACEHOLDER"
-        }
-    }
+//    signingConfigs {
+//        release {
+//            storeFile file(System.properties['KEYSTORE_PATH'])
+//            storePassword "PLACEHOLDER"
+//            keyAlias System.properties['KEYSTORE_EMAIL']
+//            keyPassword "PLACEHOLDER"
+//        }
+//    }
 
-    buildTypes {
-        release {
-            signingConfig signingConfigs.release
-        }
-    }
+//    buildTypes {
+//        release {
+//            signingConfig signingConfigs.release
+//        }
+//    }
 
     lintOptions {
         abortOnError false
@@ -39,20 +39,20 @@ dependencies {
 
 // borrowed from https://www.timroes.de/2014/01/19/using-password-prompts-with-gradle-build-files/
 // and https://www.timroes.de/2013/09/22/handling-signing-configs-with-gradle/
-gradle.taskGraph.whenReady { taskGraph ->
+//gradle.taskGraph.whenReady { taskGraph ->
     // Only execute when we are trying to assemble a release build
-    if(taskGraph.hasTask(':ScreenNotifications:assembleRelease') || taskGraph.hasTask(':ScreenNotifications:installRelease')) {
-        def password = System.console().readPassword("\nPlease enter key passphrase: ")
-
-        if(password.size() <= 0) {
-            throw new InvalidUserDataException("You must enter a password to proceed.")
-        }
-
-        // Must create String because System.readPassword() returns char[]
-        // (and assigning that below fails silently)
-        password = new String(password)
-
-        android.signingConfigs.release.storePassword = password
-        android.signingConfigs.release.keyPassword = password
-    }
-}
+//    if(taskGraph.hasTask(':ScreenNotifications:assembleRelease') || taskGraph.hasTask(':ScreenNotifications:installRelease')) {
+//        def password = System.console().readPassword("\nPlease enter key passphrase: ")
+//
+//        if(password.size() <= 0) {
+//            throw new InvalidUserDataException("You must enter a password to proceed.")
+//        }
+//
+//        // Must create String because System.readPassword() returns char[]
+//        // (and assigning that below fails silently)
+//        password = new String(password)
+//
+//        android.signingConfigs.release.storePassword = password
+//        android.signingConfigs.release.keyPassword = password
+//    }
+//}

--- a/ScreenNotifications/src/main/java/com/lukekorth/screennotifications/helpers/ScreenController.java
+++ b/ScreenNotifications/src/main/java/com/lukekorth/screennotifications/helpers/ScreenController.java
@@ -29,14 +29,14 @@ public class ScreenController {
     private Logger mLogger;
     private SharedPreferences mPrefs;
     private PowerManager mPowerManager;
-    private boolean mCloseToProximitySensor;
+    private boolean mSensorsAllowWakeUp;
 
-    public ScreenController(Context context, boolean closeToProximitySensor) {
+    public ScreenController(Context context, boolean SensorsAllowWakeUp) {
         mContext = context;
         mLogger = LoggerFactory.getLogger("ScreenController");
         mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
         mPowerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-        mCloseToProximitySensor = closeToProximitySensor;
+        mSensorsAllowWakeUp = SensorsAllowWakeUp;
     }
 
     public void handleNotification() {
@@ -54,10 +54,10 @@ public class ScreenController {
     private void turnOnScreen() {
         mLogger.debug("Turning on screen");
 
-        if(mPrefs.getBoolean("status-bar", false)) {
-            mLogger.debug("Sleeping for 3 seconds before turning on screen");
-            SystemClock.sleep(3000);
-        }
+//        if(mPrefs.getBoolean("status-bar", false)) {
+//            mLogger.debug("Sleeping for 3 seconds before turning on screen");
+//            SystemClock.sleep(3000);
+//        }
 
         int flag;
         if(mPrefs.getBoolean("bright", false)) {
@@ -124,7 +124,7 @@ public class ScreenController {
         boolean turnOnScreen = !isInQuietTime() && !isInCall() && !mPowerManager.isScreenOn();
 
         if(!mPrefs.getBoolean("proxSensor", true)) {
-            turnOnScreen = turnOnScreen && !mCloseToProximitySensor;
+            turnOnScreen = turnOnScreen && mSensorsAllowWakeUp;
         }
 
         mLogger.debug("Should turn on screen: " + turnOnScreen);

--- a/ScreenNotifications/src/main/java/com/lukekorth/screennotifications/services/NotificationListener.java
+++ b/ScreenNotifications/src/main/java/com/lukekorth/screennotifications/services/NotificationListener.java
@@ -2,14 +2,20 @@ package com.lukekorth.screennotifications.services;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.hardware.display.DisplayManager;
 import android.os.Build;
+import android.os.PowerManager;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.service.notification.NotificationListenerService;
 import android.service.notification.StatusBarNotification;
+import android.util.Log;
+import android.view.Display;
 
 import com.lukekorth.screennotifications.helpers.ScreenController;
 
@@ -18,57 +24,145 @@ import org.slf4j.LoggerFactory;
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 public class NotificationListener extends NotificationListenerService implements SensorEventListener {
 
+    private static final String TAG = "NotificationListener";
+
+    private double mAccel = SensorManager.GRAVITY_EARTH;
+
+    private float accelerometerThreshold = 2.0f;
+    private int maximumPoolingTime = 5;
+
+    private SharedPreferences mPrefs;
+    private PowerManager mPowerManager;
+    private DisplayManager dm;
+
+    private long startTime;
+    private long endTime;
+
+    private boolean inPocket=false;
+    private boolean deviceHasMoved=false;
+
+    private boolean isAlreadyPooling=false;
+
+    private boolean notificationTriggersVibration = false;
+
+    @Override
+    public void onCreate() {
+        Log.d(TAG, "onCreate: notificationListener");
+        super.onCreate();
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+        mPowerManager = (PowerManager) this.getSystemService(Context.POWER_SERVICE);
+        dm = (DisplayManager) this.getSystemService(Context.DISPLAY_SERVICE);
+    }
+
     @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
-        if (!sbn.isOngoing() && isAppEnabled(sbn)) {
-            LoggerFactory.getLogger("NotificationListener").debug("Got a non-ongoing notification for an enabled app. " + sbn.getPackageName());
-            if (isProximitySensorEnabled()) {
-                if (!registerProximitySensorListener()) {
-                    new ScreenController(this, false).handleNotification();
+        if(!isScreenOn()) {
+            //Used here, so that changes in the shared preferences are immediately reflected into the service
+            accelerometerThreshold = Float.parseFloat(mPrefs.getString("accelerometerThreshold", "2.0f"));
+            maximumPoolingTime = Integer.parseInt(mPrefs.getString("maximumPoolingTime", "5"));
+
+            Log.d(TAG, "onNotificationPosted: Got a notification for an app. " + sbn.getPackageName());
+            if (!sbn.isOngoing() && isAppEnabled(sbn)) {
+                //used to check if phone vibrates because of the notification and then change the sensor listening later
+                notificationTriggersVibration = (sbn.getNotification().defaults != 0 || sbn.getNotification().vibrate != null);
+
+                if (isAlreadyPooling) {
+                    startTime = SystemClock.elapsedRealtime();
+                    endTime = SystemClock.elapsedRealtime();
+                } else {
+                    LoggerFactory.getLogger("NotificationListener").debug("Got a non-ongoing notification for an enabled app. " + sbn.getPackageName());
+
+                    if (isProximitySensorEnabled()) {
+                        if (!registerSensorListeners()) {
+                            Log.d(TAG, "registerSensorListeners was false");
+                            new ScreenController(this, true).handleNotification();
+                        }
+                    } else {
+                        Log.d(TAG, "ProximitySensor NOT Enabled");
+                        new ScreenController(this, true).handleNotification();
+                    }
                 }
-            } else {
-                new ScreenController(this, false).handleNotification();
             }
         }
     }
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        endTime = SystemClock.elapsedRealtime();
         if (event.sensor.getType() == Sensor.TYPE_PROXIMITY) {
-            unregisterProximitySensorListener();
+            inPocket = event.values[0] < event.sensor.getMaximumRange();
+        }
 
-            boolean close = event.values[0] < event.sensor.getMaximumRange();
-            new ScreenController(this, close).handleNotification();
+        //Currently the sensor is only used after some time if the phone vibrates, because otherwise the vibration of a notification might give us false data. Maybe use low-pass filter or other sensors to distinguish between vibration caused movement or real movement of the device
+        if (event.sensor.getType() == Sensor.TYPE_LINEAR_ACCELERATION && (!notificationTriggersVibration || (endTime - startTime)/1000f > 1.5)) {
+            float x = event.values[0];
+            float y = event.values[1];
+            float z = event.values[2];
+            mAccel = Math.sqrt(x*x + y*y + z*z);
+            Log.d(TAG, "mAccel:"+mAccel);
+
+            deviceHasMoved = (mAccel > accelerometerThreshold);
+        }
+
+        Log.d(TAG, "onSensorChanged: shouldSensorsWakeUpDevice:" + (!inPocket&&deviceHasMoved)+ " time:"+(endTime - startTime)/1000);
+        if ((!inPocket&&deviceHasMoved) || (endTime - startTime)/1000 > maximumPoolingTime) {
+            unregisterSensorListeners();
+            new ScreenController(this, (!inPocket&&deviceHasMoved)).handleNotification();
+            inPocket=false;
+            deviceHasMoved=false;
+            isAlreadyPooling=false;
+            notificationTriggersVibration=false;
         }
     }
 
     private boolean isAppEnabled(StatusBarNotification sbn) {
-        return PreferenceManager.getDefaultSharedPreferences(this).getBoolean(sbn.getPackageName(), false);
+        return mPrefs.getBoolean(sbn.getPackageName(), false);
     }
 
     private boolean isProximitySensorEnabled() {
-        return !PreferenceManager.getDefaultSharedPreferences(this).getBoolean("proxSensor", true);
+        return !mPrefs.getBoolean("proxSensor", true);
     }
 
-    private boolean registerProximitySensorListener() {
+    private boolean registerSensorListeners() {
+        startTime = SystemClock.elapsedRealtime();
+        isAlreadyPooling=true;
         SensorManager sensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
         Sensor proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        Sensor accelerometerSensor = sensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION);
 
         if (proximitySensor == null) {
             return false;
         } else {
             sensorManager.registerListener(this, proximitySensor, SensorManager.SENSOR_DELAY_NORMAL);
-            return true;
         }
+        sensorManager.registerListener(this, accelerometerSensor, SensorManager.SENSOR_DELAY_NORMAL);
+        return true;
     }
 
-    private void unregisterProximitySensorListener() {
+    private void unregisterSensorListeners() {
         ((SensorManager) getSystemService(Context.SENSOR_SERVICE)).unregisterListener(this);
     }
 
     @Override
-    public void onNotificationRemoved(StatusBarNotification sbn) {}
+    public void onNotificationRemoved(StatusBarNotification sbn) {
+        //TODO: Allow option to have sensors active until notification was read. This consumes more battery, but then whenever he moves the device it will wake up, makes only sense for accelerometer mode
+    }
 
     @Override
-    public void onAccuracyChanged(Sensor sensor, int accuracy) {}
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+    }
+
+    public boolean isScreenOn() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            boolean screenOn = false;
+            for (Display display : dm.getDisplays()) {
+                if (display.getState() != Display.STATE_OFF) {
+                    screenOn = true;
+                }
+            }
+            return screenOn;
+        } else {
+            return mPowerManager.isScreenOn();
+        }
+    }
 }

--- a/ScreenNotifications/src/main/java/com/lukekorth/screennotifications/services/ScreenNotificationsService.java
+++ b/ScreenNotifications/src/main/java/com/lukekorth/screennotifications/services/ScreenNotificationsService.java
@@ -2,11 +2,17 @@ package com.lukekorth.screennotifications.services;
 
 import android.accessibilityservice.AccessibilityService;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.hardware.display.DisplayManager;
+import android.os.Build;
+import android.os.PowerManager;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
+import android.view.Display;
 import android.view.accessibility.AccessibilityEvent;
 
 import com.lukekorth.screennotifications.helpers.ScreenController;
@@ -14,55 +20,107 @@ import com.lukekorth.screennotifications.helpers.ScreenController;
 import org.slf4j.LoggerFactory;
 
 public class ScreenNotificationsService extends AccessibilityService implements SensorEventListener {
+    private double mAccel = SensorManager.GRAVITY_EARTH;
+
+    private float accelerometerThreshold = 2.0f;
+    private int maximumPoolingTime = 5;
+
+    private SharedPreferences mPrefs;
+    private PowerManager mPowerManager;
+    private DisplayManager dm;
+
+    private long startTime;
+    private long endTime;
+
+    private boolean inPocket=false;
+    private boolean deviceHasMoved=false;
+    private boolean isAlreadyPooling=false;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+        mPowerManager = (PowerManager) this.getSystemService(Context.POWER_SERVICE);
+        dm = (DisplayManager) this.getSystemService(Context.DISPLAY_SERVICE);
+    }
 
     @Override
     public void onAccessibilityEvent(AccessibilityEvent event) {
-        if (event.getEventType() == AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED &&
-                isAppEnabled(event)) {
-            LoggerFactory.getLogger("BaseAccessibilityService")
-                    .debug("Received a notification accessibility event for an enabled app. " + event.getPackageName());
-            if (isProximitySensorEnabled()) {
-                if (!registerProximitySensorListener()) {
-                    new ScreenController(this, false).handleNotification();
+        if(!isScreenOn()) {
+            //Used here, so that changes in the shared preferences are immediately reflected into the service
+            accelerometerThreshold = Float.parseFloat(mPrefs.getString("accelerometerThreshold", "2.0f"));
+            maximumPoolingTime = Integer.parseInt(mPrefs.getString("maximumPoolingTime", "5"));
+            if (event.getEventType() == AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED &&
+                    isAppEnabled(event)) {
+                if (isAlreadyPooling) {
+                    startTime = SystemClock.elapsedRealtime();
+                    endTime = SystemClock.elapsedRealtime();
+                } else {
+                    LoggerFactory.getLogger("BaseAccessibilityService")
+                            .debug("Received a notification accessibility event for an enabled app. " + event.getPackageName());
+                    if (isProximitySensorEnabled()) {
+                        if (!registerSensorListeners()) {
+                            new ScreenController(this, true).handleNotification();
+                        }
+                    } else {
+                        new ScreenController(this, true).handleNotification();
+                    }
                 }
-            } else {
-                new ScreenController(this, false).handleNotification();
             }
         }
     }
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        endTime = SystemClock.elapsedRealtime();
         if (event.sensor.getType() == Sensor.TYPE_PROXIMITY) {
-            unregisterProximitySensorListener();
+            inPocket = event.values[0] < event.sensor.getMaximumRange();
+        }
 
-            boolean close = event.values[0] < event.sensor.getMaximumRange();
-            new ScreenController(this, close).handleNotification();
+        //Currently the sensor is only used after some time, because otherwise the vibration of a notification might give us false data. Maybe use low-pass filter or other sensors to distinguish between vibration caused movement or real movement of the device
+        if (event.sensor.getType() == Sensor.TYPE_LINEAR_ACCELERATION && (endTime - startTime)/1000f > 1.5) {
+            float x = event.values[0];
+            float y = event.values[1];
+            float z = event.values[2];
+            mAccel = Math.sqrt(x*x + y*y + z*z);
+
+            deviceHasMoved = (mAccel > accelerometerThreshold);
+        }
+
+        if ((!inPocket&&deviceHasMoved) || (endTime - startTime)/1000 > maximumPoolingTime) {
+            unregisterSensorListeners();
+            new ScreenController(this, (!inPocket&&deviceHasMoved)).handleNotification();
+            inPocket=false;
+            deviceHasMoved=false;
+            isAlreadyPooling=false;
         }
     }
 
     private boolean isAppEnabled(AccessibilityEvent event) {
-        return PreferenceManager.getDefaultSharedPreferences(this)
-                .getBoolean(event.getPackageName().toString(), false);
+        return mPrefs.getBoolean(event.getPackageName().toString(), false);
     }
 
     private boolean isProximitySensorEnabled() {
-        return !PreferenceManager.getDefaultSharedPreferences(this).getBoolean("proxSensor", true);
+        return !mPrefs.getBoolean("proxSensor", true);
     }
 
-    private boolean registerProximitySensorListener() {
+    private boolean registerSensorListeners() {
+        startTime = SystemClock.elapsedRealtime();
+        isAlreadyPooling=true;
         SensorManager sensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
         Sensor proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        Sensor accelerometerSensor = sensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION);
 
         if (proximitySensor == null) {
             return false;
         } else {
             sensorManager.registerListener(this, proximitySensor, SensorManager.SENSOR_DELAY_NORMAL);
-            return true;
         }
+        sensorManager.registerListener(this, accelerometerSensor, SensorManager.SENSOR_DELAY_NORMAL);
+        return true;
     }
 
-    private void unregisterProximitySensorListener() {
+    private void unregisterSensorListeners() {
         ((SensorManager) getSystemService(Context.SENSOR_SERVICE)).unregisterListener(this);
     }
 
@@ -72,4 +130,17 @@ public class ScreenNotificationsService extends AccessibilityService implements 
     @Override
     public void onAccuracyChanged(Sensor sensor, int accuracy) {}
 
+    public boolean isScreenOn() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            boolean screenOn = false;
+            for (Display display : dm.getDisplays()) {
+                if (display.getState() != Display.STATE_OFF) {
+                    screenOn = true;
+                }
+            }
+            return screenOn;
+        } else {
+            return mPowerManager.isScreenOn();
+        }
+    }
 }

--- a/ScreenNotifications/src/main/res/values-cs/strings.xml
+++ b/ScreenNotifications/src/main/res/values-cs/strings.xml
@@ -12,7 +12,7 @@
   <string name="wake_length">Doba probuzení displeje</string>
   <string name="full_brightness">Maximální jas</string>
   <string name="full_brightness_summary">Při zaškrtnutí bude displej zapnutý s maximálním jasem</string>
-  <string name="disable_sensor">Vypnutí Proximity senzoru</string>
+  <string name="disable_sensor">Vypnutí senzoru</string>
   <string name="disable_sensor_summary">Pokud je zaškrtnuto zapne se displej při oznámení, i když máte telefon v kapse</string>
   <string name="quiet_time">Noční režim</string>
   <string name="experimental">Experimentální funkce</string>
@@ -28,4 +28,5 @@
   <string name="statusBar">Otevření notifikační lišty</string>
   <string name="statusBarSum">Otevře notifikační lištu když oznámení zapne displej.\nToto je experimentální funkce, která bude fungovat jen na některých telefonech.</string>
   <string name="market_description">\n        Jednoduchá aplikace která zapne displej při oznámení z vybraných aplikací.  \n        Když je telefon v kapse nebo pouzdře tak se díky proximity senzoru displej nezapne.\n\n\t\tNápady a přání jsou vítány.\n\t\t\n\t\tProsím pište mi na email. Jestli chcete pomocí s překladem, navštivte následující web: \n\t\thttps://www.transifex.com/projects/p/screen-notifications/\n\n\t\tJestli narazíte na chybu nebo problém, zastihnete mě na github: \n\t\thttps://github.com/lkorth/screen-notifications\n    </string>
+  <string name="maximumPoolingTime"></string>
 </resources>

--- a/ScreenNotifications/src/main/res/values-de/strings.xml
+++ b/ScreenNotifications/src/main/res/values-de/strings.xml
@@ -16,4 +16,10 @@
   <string name="quietHours">Ruhezeit einschalten</string>
   <string name="quietSum">Das Display wird während der Ruhezeiten nicht durch Benachrichtigungen eingeschaltet</string>
   <string name="statusBarSum">Öffnet die Benachrichtigungsleiste wenn das Display durch eine Benachrichtigung aktiviert wird.\nDies ist experimentell und wird nur bei wenigen Telefonen funktionieren. Andererseits wird es keine Probleme bereiten, falls es auf diesem Telefon nicht funktioniert.</string>
+  <string name="disable_sensor">Sensoren deaktivieren</string>
+  <string name="disable_sensor_summary">Wenn aktiviert, schaltet sich das Display bei einer Benachrichtigung sofort ein. Auch wenn es in der Tasche steckt.</string>
+  <string name="maximumPoolingTime_summary">Legt fest wie lange die Sensoren (in Sekunden) aktiv sein sollen um das Gerät aufzuwecken. Höhere Werte verbrauchen etwas mehr Strom.</string>
+  <string name="accelerometerThreshold">Beschleunigungssensor Sensibilität</string>
+  <string name="accelerometerThreshold_summary">Kleinere Werte werden das Gerät eher aufwecken, während höhere Werte erst bei starken Bewegungen das Gerät aufwecken werden. (Standard ist 2)</string>
+  <string name="maximumPoolingTime">Zeitspanne für Sensoren</string>
 </resources>

--- a/ScreenNotifications/src/main/res/values-it/strings.xml
+++ b/ScreenNotifications/src/main/res/values-it/strings.xml
@@ -12,7 +12,7 @@
   <string name="wake_length">Durata accensione schermo</string>
   <string name="full_brightness">Luminosità Massima</string>
   <string name="full_brightness_summary">Se selezionato, lo schermo si accenderà sempre a luminosità massima alla ricezione di notifiche</string>
-  <string name="disable_sensor">Disattiva Sensore di Prossimità</string>
+  <string name="disable_sensor">Disattiva Sensore</string>
   <string name="disable_sensor_summary">Se selezionato, lo schermo si accenderà sempre alla ricezione di notifiche, anche se è in tasca</string>
   <string name="quiet_time">Periodo di Quiete</string>
   <string name="experimental">Sperimentale</string>

--- a/ScreenNotifications/src/main/res/values-nl-rNL/strings.xml
+++ b/ScreenNotifications/src/main/res/values-nl-rNL/strings.xml
@@ -12,7 +12,7 @@
   <string name="wake_length">Lengte van actief scherm</string>
   <string name="full_brightness">Volledige helderheid</string>
   <string name="full_brightness_summary">Wanneer geactiveerd, zal het scherm altijd op volle helderheid gaan voor de nofiticaties</string>
-  <string name="disable_sensor">Deactiveer omgeving sensor</string>
+  <string name="disable_sensor">Deactiveer sensors</string>
   <string name="disable_sensor_summary">Wanneer geactiveerd, zal het scherm aan gaan voor notificaties. Ook als deze in u zak zit</string>
   <string name="quiet_time">Rust tijd</string>
   <string name="experimental">Experiment</string>

--- a/ScreenNotifications/src/main/res/values/strings.xml
+++ b/ScreenNotifications/src/main/res/values/strings.xml
@@ -30,8 +30,8 @@
     <string name="disabled_wake_length">Device Admin option must be enabled first</string>
     <string name="full_brightness">Full Brightness</string>
     <string name="full_brightness_summary">When checked, the screen will always turn on at full brightness for notifications</string>
-    <string name="disable_sensor">Disable Proximity Sensor</string>
-    <string name="disable_sensor_summary">When checked, the screen will always turn on for notifications, even in your pocket</string>
+    <string name="disable_sensor">Disable Sensors</string>
+    <string name="disable_sensor_summary">When checked, the screen will always turn on for notifications, even in your pocket. </string>
     <string name="quiet_time">Quiet Time</string>
     <string name="experimental">Experimental</string>
     <string name="help">Help</string>
@@ -48,7 +48,9 @@
     <string name="stopTime">Stop quiet hours</string>
     <string name="set">Set</string>
     <string name="statusBar">Open notification tray</string>
-    <string name="statusBarSum">Open the notification tray when the screen is turned on due to a notification. 
+    <string name="test_notification">Test Notification</string>
+    <string name="test_notification_summary">This will create a test notification after 5 seconds</string>
+    <string name="statusBarSum">Open the notification tray when the screen is turned on due to a notification.
         This is experimental and will only work on a small number of phones. It will not cause any issues if it 
         does not work on your phone.</string>
 
@@ -64,4 +66,8 @@
 		If you have issues or enhancements, fork me on github:
 		https://github.com/lkorth/screen-notifications
     </string>
+    <string name="maximumPoolingTime">Maximum Pooling Time</string>
+    <string name="maximumPoolingTime_summary">Defines in seconds how long the sensors should listen for movement or proximity to wake up device. Higher values will use a little bit more battery</string>
+    <string name="accelerometerThreshold">Accelerometer Sensibility</string>
+    <string name="accelerometerThreshold_summary">A lower value will wake up the device more easily when it moves, higher values will make it wake up only when it is moved more (default=2)</string>
 </resources>

--- a/ScreenNotifications/src/main/res/xml/settings.xml
+++ b/ScreenNotifications/src/main/res/xml/settings.xml
@@ -12,6 +12,10 @@
             android:key="device_admin"
             android:title="@string/admin_title"
             android:summary="@string/admin_summary" />
+        <Preference
+            android:key="test_notification"
+            android:title="@string/test_notification"
+            android:summary="@string/test_notification_summary" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/apps" >
         <Preference
@@ -34,10 +38,22 @@
             android:title="@string/full_brightness"
             android:summary="@string/full_brightness_summary" />
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="proxSensor"
             android:title="@string/disable_sensor"
             android:summary="@string/disable_sensor_summary" />
+        <EditTextPreference
+            android:defaultValue="5"
+            android:inputType="number"
+            android:title="@string/maximumPoolingTime"
+            android:summary="@string/maximumPoolingTime_summary"
+            android:key="maximumPoolingTime"/>
+        <EditTextPreference
+            android:defaultValue="2"
+            android:inputType="number"
+            android:title="@string/accelerometerThreshold"
+            android:summary="@string/accelerometerThreshold_summary"
+            android:key="accelerometerThreshold"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/quiet_time">
         <CheckBoxPreference
@@ -64,6 +80,12 @@
             android:title="@string/statusBar" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/help">
+        <Preference
+            android:selectable="false"
+            android:enabled="true"
+            android:key="restarting_info"
+            android:title="It does not work?!"
+            android:summary="Try to restart your phone, sometimes the app can just receive and react to notifications after the phone was restarted." />
         <Preference
             android:key="contact"
             android:title="@string/contact"

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
     }
 }
 
@@ -11,4 +12,7 @@ allprojects {
     repositories {
         mavenCentral()
     }
+}
+task wrapper(type: Wrapper) {
+    gradleVersion = "2.10"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Mainly i wanted to use the accelerometer, so that i can have e.g. my phone on my desk; a notification comes in and then only if i lift it up, the screen goes on. I don't have any lookscreen or so, so i usually also have the option on to scroll down the statusbar.

But then i also updated the gradle tool builds etc. and had problems that the service didn't started on Android M(N5, 6.0.1r3). Therefore i added a binder to the service and manually invoked it. Even then sometimes the user needs to restart the device(added that as a hint to the preferences).

Next thing was to have an option to test the whole app. This is also nice for a user, so i added this option to the settingsfragment.

Lastly i wanted to avoid that the whole service fires, when the screen is already on (if the status bar scroll is on this can lead to some weird behaviour a la "ups why did my statusbar scrolled down?!")